### PR TITLE
Add markdown-lint to github workflow

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: markdownlint-cli
+        uses: nosborn/github-action-markdown-cli@v1.1.1

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  lint-markdown:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,3 +17,5 @@ jobs:
 
       - name: markdownlint-cli
         uses: nosborn/github-action-markdown-cli@v1.1.1
+        with:
+          files: .


### PR DESCRIPTION
Uses [github-action-markdownlint-cli](https://github.com/marketplace/actions/markdownlint-cli) to validate all markdown files.